### PR TITLE
Acme API v2 update

### DIFF
--- a/deploy/cert-manager-setup/letsencrypt-clusterissuer-prod.yaml
+++ b/deploy/cert-manager-setup/letsencrypt-clusterissuer-prod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   acme:
     # The ACME production server URL
-    server: https://acme-v01.api.letsencrypt.org/directory
+    server: https://acme-v02.api.letsencrypt.org/directory
     # Email address used for ACME registration
     email: myemail@gmail.com
     # Name of a secret used to store the ACME account private key


### PR DESCRIPTION
API v1 returns a configuration error at the cluster, telling to use the v2.